### PR TITLE
Update laff-pack.php

### DIFF
--- a/laff-pack.php
+++ b/laff-pack.php
@@ -291,8 +291,8 @@ class LAFFPack {
 		$sle = $this->_calc_longest_edge($boxes, $edges);
 		
 		return array(
-			'length' => $sle['edge_size'],
-			'width' => $le['edge_size'],
+			'length' => $le['edge_size'],
+			'width' => $sle['edge_size'],
 			'height' => 0
 		);
 	}


### PR DESCRIPTION
The following example fails:

$boxes = array(
	array(
		'length' => 60,
		'width' => 32,
		'height' => 30,
        'boxid' => 'Peixera'
	),
	array(
		'length' => 19,
		'width' => 35,
		'height' => 20,
        'boxid' => 'Tortuguera'
	)
);

Please, update the algorithm to solve this issue.

Thank's,

Xavi